### PR TITLE
Fix crash in InvokeLogsAsync 

### DIFF
--- a/PassKitHelper/PassKitMiddleware.cs
+++ b/PassKitHelper/PassKitMiddleware.cs
@@ -303,7 +303,7 @@
                 return;
             }
 
-            if (context.Request.Body.Length == 0)
+            if (context.Request.Body.CanSeek && context.Request.Body.Length == 0)
             {
                 return;
             }


### PR DESCRIPTION
InvokeLogsAsync crashes when reading Length property of non-seekable streams as is the case with Request.Body.