### PR TITLE
Make Apple WWDRCA Certificate optional in some case

### DIFF
--- a/PassKitHelper/PassKitHelper.cs
+++ b/PassKitHelper/PassKitHelper.cs
@@ -60,7 +60,7 @@
         /// <inheritdoc cref="IPassKitHelper.SendPushNotificationAsync(string)" />
         public async Task<bool> SendPushNotificationAsync(string pushToken)
         {
-            ValidateOptions();
+            ValidateOptions(false);
 
             using var client = httpClientAccessor?.Invoke() ?? CreateNewHttpClient();
 
@@ -106,9 +106,9 @@
         /// <summary>
         /// Validates options before use.
         /// </summary>
-        protected void ValidateOptions()
+        protected void ValidateOptions(bool validateAppleCert = true)
         {
-            if (options.AppleCertificate == null)
+            if (validateAppleCert && options.AppleCertificate == null)
             {
                 throw new InvalidOperationException("AppleCertificate must not be null");
             }


### PR DESCRIPTION
I'm using a dedicated `PassKitHelper` instance in one of my services singletons for sending Push notifications. The Apple Merchant Certificate is not used in this case but still required since the `ValidateOptions` method insists on it. The reason for even creating this PR is because in my case there are situations where the Pass Certificate is always available but the Merchant Cert is tied to a customer which is sometimes not contextually available. Requiring me to load a fallback cert just to satisfy `ValidateOptions`. 😊